### PR TITLE
Pack of fixes

### DIFF
--- a/core/TagParser.php
+++ b/core/TagParser.php
@@ -47,7 +47,7 @@ class TagParser extends Object
         'link' => ['class' => 'luya\tag\tags\LinkTag'],
     ];
     
-    private static $_instance = null;
+    private static $_instance;
     
     /**
      * Inject a new tag with a given name and a configurable array config.
@@ -156,7 +156,7 @@ class TagParser extends Object
             $tag = $row['function'];
             if ($this->hasTag($tag)) {
                 $replace = $this->evalTag($tag, $row);
-                $text = preg_replace('['.preg_quote($row[0]).']mi', $replace, $text, 1);
+                $text = preg_replace('/'.preg_quote($row[0], '/').'/mi', $replace, $text, 1);
             }
         }
         

--- a/core/base/BaseBootstrap.php
+++ b/core/base/BaseBootstrap.php
@@ -16,7 +16,7 @@ abstract class BaseBootstrap implements BootstrapInterface
     /**
      * @var array Readonly variable contains all module Objects.
      */
-    private $_modules = null;
+    private $_modules;
 
     /**
      * Boostrap method will be invoken by Yii Application bootrapping proccess containing

--- a/core/base/Boot.php
+++ b/core/base/Boot.php
@@ -34,7 +34,7 @@ abstract class Boot
     /**
      * @var \luya\web\Application|\luya\console\Application The application object.
      */
-    public $app = null;
+    public $app;
 
     /**
      * @var bool When enabled the boot process will not return/echo something, but the variabled will contain the Application object.
@@ -44,7 +44,7 @@ abstract class Boot
     /**
      * @var string Path to the Yii.php file.
      */
-    private $_baseYiiFile = null;
+    private $_baseYiiFile;
 
     /**
      * Setter method for the base Yii file.
@@ -84,7 +84,7 @@ abstract class Boot
         return strtolower(php_sapi_name());
     }
 
-    private $_configArray = null;
+    private $_configArray;
     
     /**
      * This method allows you to directly inject a configuration array instead of using the config file

--- a/core/base/Module.php
+++ b/core/base/Module.php
@@ -99,7 +99,7 @@ abstract class Module extends \yii\base\Module
      * name inside the child modules $context variable. For example the cms includes the news module, the context variable
      * of news would have the value "cms".
      */
-    public $context = null;
+    public $context;
 
     /**
      * @var string The default name of the moduleLayout

--- a/core/base/ModuleReflection.php
+++ b/core/base/ModuleReflection.php
@@ -41,19 +41,19 @@ class ModuleReflection extends Object
     /**
      * @var \luya\web\Request Request object from DI-Container.
      */
-    public $request = null;
+    public $request;
 
     /**
      * @var \luya\web\UrlManager UrlManager object from DI-Container.
      */
-    public $urlManager = null;
+    public $urlManager;
     
     /**
      * @var \yii\base\Controller|null The controller paramter is null until the [[run()]] method has been applied.
      */
-    public $controller = null;
+    public $controller;
 
-    private $_defaultRoute = null;
+    private $_defaultRoute;
 
     /**
      * Class constructor in order to consum from DI Container.
@@ -82,7 +82,7 @@ class ModuleReflection extends Object
         $this->urlManager->addRules($this->module->urlRules, true);
     }
 
-    private $_module = null;
+    private $_module;
     
     /**
      * Setter for the module property.
@@ -104,7 +104,7 @@ class ModuleReflection extends Object
         return $this->_module;
     }
     
-    private $_suffix = null;
+    private $_suffix;
     
     /**
      * Setter for the suffix property.
@@ -127,7 +127,7 @@ class ModuleReflection extends Object
         return $this->_suffix;
     }
     
-    private $_requestRoute = null;
+    private $_requestRoute;
 
     /**
      * Determine the default route based on current defaultRoutes or parsedRequested by the UrlManager.

--- a/core/components/Mail.php
+++ b/core/components/Mail.php
@@ -35,7 +35,7 @@ use yii\base\Controller;
  */
 class Mail extends \yii\base\Component
 {
-    private $_mailer = null;
+    private $_mailer;
 
     /**
      * @var string sender email address
@@ -60,7 +60,7 @@ class Mail extends \yii\base\Component
     /**
      * @var string email server password
      */
-    public $password = null; // insert password
+    public $password; // insert password
 
     /**
      * @var bool disable if you want to use old PHP sendmail

--- a/core/console/ErrorHandler.php
+++ b/core/console/ErrorHandler.php
@@ -18,5 +18,5 @@ class ErrorHandler extends \yii\console\ErrorHandler
      * @var streing This propertie has been added in order to make sure console commands config
      * does also work in console env.
      */
-    public $errorAction = null;
+    public $errorAction;
 }

--- a/core/console/Importer.php
+++ b/core/console/Importer.php
@@ -46,7 +46,7 @@ abstract class Importer extends \yii\base\Object
     /**
      * @var mixed|array Read only property contains the importer object.
      */
-    private $_importer = null;
+    private $_importer;
 
     /**
      * Class constructor containing the importer object from where its called.

--- a/core/lazyload/LazyLoad.php
+++ b/core/lazyload/LazyLoad.php
@@ -25,17 +25,17 @@ class LazyLoad extends Widget
     /**
      * @var string The path to the image you want to lazy load.
      */
-    public $src = null;
+    public $src;
     
     /**
      * @var integer The width of the image, this information should be provided in order to display a placeholder.
      */
-    public $width = null;
+    public $width;
     
     /**
      * @var integer The height of the image, this information should be provided in order to display a placeholder.
      */
-    public $height = null;
+    public $height;
 
     /**
      * @var boolean Define whether a full image tag should be return or only the attributes. This can be applied when using the lazy loader in background images.
@@ -45,7 +45,7 @@ class LazyLoad extends Widget
     /**
      * @var string Additional classes for the lazy load image.
      */
-    public $extraClass = null;
+    public $extraClass;
     
     /**
      * @inheritdoc

--- a/core/tag/BaseTag.php
+++ b/core/tag/BaseTag.php
@@ -15,7 +15,7 @@ use yii\base\Object;
  */
 abstract class BaseTag extends Object implements TagInterface
 {
-    private $_view = null;
+    private $_view;
     
     /**
      * Get the view object to register assets in tags.

--- a/core/traits/ApplicationTrait.php
+++ b/core/traits/ApplicationTrait.php
@@ -18,7 +18,7 @@ use luya\base\CoreModuleInterface;
  */
 trait ApplicationTrait
 {
-    private $_webroot = null;
+    private $_webroot;
     
     /**
      * @var string Title for the application used in different sections like Login screen

--- a/core/traits/CacheableTrait.php
+++ b/core/traits/CacheableTrait.php
@@ -62,7 +62,7 @@ trait CacheableTrait
     /**
      * @var boolean Whether the caching is enabled or disabled.
      */
-    private $_cachable = null;
+    private $_cachable;
     
     /**
      * Check if the current configuration of the application and the property allows a caching of the

--- a/core/web/Composition.php
+++ b/core/web/Composition.php
@@ -32,7 +32,7 @@ class Composition extends Component implements \ArrayAccess
     /**
      * @var \yii\web\Request Request-Object container from DI
      */
-    public $request = null;
+    public $request;
 
     /**
      * @var bool Enable or disable the->getFull() prefix. If disabled the response of getFull() would be empty, otherwhise it
@@ -309,7 +309,7 @@ class Composition extends Component implements \ArrayAccess
      */
     public function removeFrom($route)
     {
-        $pattern = preg_quote($this->getFull().'/');
+        $pattern = preg_quote($this->getFull().'/', '#');
 
         return preg_replace("#$pattern#", '', $route, 1);
     }

--- a/core/web/CompositionAfterSetEvent.php
+++ b/core/web/CompositionAfterSetEvent.php
@@ -13,10 +13,10 @@ class CompositionAfterSetEvent extends \yii\base\Event
     /**
      * @var string The key identifiere where the value will be set (array key).
      */
-    public $key = null;
+    public $key;
     
     /**
      * @var string The value for the specific key to set (array value).
      */
-    public $value = null;
+    public $value;
 }

--- a/core/web/Element.php
+++ b/core/web/Element.php
@@ -84,7 +84,7 @@ class Element extends \yii\base\Component
     /**
      * @var string Parsed path of the folder where the view files are stored.
      */
-    private $_folder = null;
+    private $_folder;
 
     /**
      * Yii intializer, is loading the default elements.php if existing.

--- a/core/web/ExternalLink.php
+++ b/core/web/ExternalLink.php
@@ -43,7 +43,7 @@ class ExternalLink extends Object implements LinkInterface, Arrayable
         return ['href', 'target'];
     }
     
-    private $_href = null;
+    private $_href;
     
     /**
      * Set the href value for an external link resource.

--- a/core/web/JsonLd.php
+++ b/core/web/JsonLd.php
@@ -109,7 +109,7 @@ class JsonLd extends Object
         Yii::$app->view->params['@graph'][] = $json;
     }
     
-    private static $_view = null;
+    private static $_view;
     
     private static function registerView()
     {

--- a/core/web/Request.php
+++ b/core/web/Request.php
@@ -37,7 +37,7 @@ class Request extends \yii\web\Request
         'application/json' => 'yii\web\JsonParser',
     ];
     
-    private $_isAdmin = null;
+    private $_isAdmin;
     
     /**
      * Setter method to force isAdmin request.

--- a/core/web/UrlManager.php
+++ b/core/web/UrlManager.php
@@ -39,11 +39,11 @@ class UrlManager extends \yii\web\UrlManager
      *
      * This context setter is called in {{luya\cms\frontend\base\Controller::renderItem}} method and is used when calling {{\luya\web\UrlManager::createUrl}} method.
      */
-    public $contextNavItemId = null;
+    public $contextNavItemId;
 
-    private $_menu = null;
+    private $_menu;
 
-    private $_composition = null;
+    private $_composition;
 
     /**
      * Ensure whether a route starts with a language short key or not.
@@ -191,7 +191,7 @@ class UrlManager extends \yii\web\UrlManager
      */
     public function removeBaseUrl($route)
     {
-        return preg_replace('#'.preg_quote($this->baseUrl).'#', '', $route, 1);
+        return preg_replace('#'.preg_quote($this->baseUrl, '#').'#', '', $route, 1);
     }
 
     /**

--- a/core/web/filters/ResponseCache.php
+++ b/core/web/filters/ResponseCache.php
@@ -100,7 +100,7 @@ class ResponseCache extends ActionFilter
      * If [[cacheCookies]] or [[cacheHeaders]] is enabled, then [[\yii\caching\Dependency::reusable]] should be enabled as well to save performance.
      * This is because the cookies and headers are currently stored separately from the actual page content, causing the dependency to be evaluated twice.
      */
-    public $dependency = null;
+    public $dependency;
     
     /**
      * @var array The list of actions where the ResponseCache should be applied. You have to define the actions otherwhise the Response
@@ -176,7 +176,7 @@ class ResponseCache extends ActionFilter
         $this->setHasCache($this->calculateCacheKey(), $event->sender->content, $this->dependency, $this->duration);
     }
     
-    private $_cacheKey = null;
+    private $_cacheKey;
     
     /**
      * Calculate the cache key based in several informations in order to make cache key unique.

--- a/envs/dev/modules/contactmanager/frontend/controllers/DefaultController.php
+++ b/envs/dev/modules/contactmanager/frontend/controllers/DefaultController.php
@@ -9,7 +9,7 @@ use yii\captcha\CaptchaAction;
 
 class F extends Model
 {
-    public $verifyCode = null;
+    public $verifyCode;
 }
 class DefaultController extends Controller
 {

--- a/modules/account/src/frontend/base/RegisterForm.php
+++ b/modules/account/src/frontend/base/RegisterForm.php
@@ -7,7 +7,7 @@ use luya\account\RegisterInterface;
 
 abstract class RegisterForm extends \yii\base\Model implements RegisterInterface
 {
-    private $_model = null;
+    private $_model;
     
     protected $modelClass = 'luya\account\models\User';
     

--- a/modules/account/src/models/User.php
+++ b/modules/account/src/models/User.php
@@ -7,9 +7,9 @@ use luya\admin\ngrest\base\NgRestModel;
 
 class User extends NgRestModel implements \yii\web\IdentityInterface
 {
-    public $password_confirm = null;
+    public $password_confirm;
 
-    public $plainPassword = null;
+    public $plainPassword;
 
     public function init()
     {

--- a/modules/admin/src/aws/CoordinatesActiveWindow.php
+++ b/modules/admin/src/aws/CoordinatesActiveWindow.php
@@ -32,7 +32,7 @@ class CoordinatesActiveWindow extends ActiveWindow
      * @var string Register your maps application and enter your api key here
      * while configure the active window (https://console.developers.google.com).
      */
-    public $mapsApiKey = null;
+    public $mapsApiKey;
     
     /**
      * @inheritdoc

--- a/modules/admin/src/aws/DetailViewActiveWindow.php
+++ b/modules/admin/src/aws/DetailViewActiveWindow.php
@@ -90,7 +90,7 @@ class DetailViewActiveWindow extends ActiveWindow
      * - `captionOptions`: the HTML attributes to customize label tag. For example: `['class' => 'bg-red']`.
      *   Please refer to [[\yii\helpers\BaseHtml::renderTagAttributes()]] for the supported syntax.
      */
-    public $attributes = null;
+    public $attributes;
     
     /**
      * Renders the index file of the ActiveWindow.

--- a/modules/admin/src/aws/FlowActiveWindow.php
+++ b/modules/admin/src/aws/FlowActiveWindow.php
@@ -53,7 +53,7 @@ class FlowActiveWindow extends ActiveWindow
      */
     public $icon = 'cloud_upload';
     
-    public $modelClass = null;
+    public $modelClass;
     
     /**
      * @inheritdoc
@@ -93,7 +93,7 @@ class FlowActiveWindow extends ActiveWindow
         ]);
     }
     
-    private $_model = null;
+    private $_model;
     
     public function getModel()
     {

--- a/modules/admin/src/aws/ImageSelectCollectionActiveWindow.php
+++ b/modules/admin/src/aws/ImageSelectCollectionActiveWindow.php
@@ -33,11 +33,11 @@ use luya\admin\ngrest\base\ActiveWindow;
  */
 class ImageSelectCollectionActiveWindow extends ActiveWindow
 {
-    public $refTableName = null;
+    public $refTableName;
 
-    public $imageIdFieldName = null;
+    public $imageIdFieldName;
 
-    public $refFieldName = null;
+    public $refFieldName;
 
     /**
      * @var string The name of the module where the active windows is located in order to finde the view path.

--- a/modules/admin/src/aws/TagActiveWindow.php
+++ b/modules/admin/src/aws/TagActiveWindow.php
@@ -57,7 +57,7 @@ class TagActiveWindow extends ActiveWindow
      */
     public $icon = "view_list";
 
-    private $_tableName = null;
+    private $_tableName;
     
     public function getTableName()
     {

--- a/modules/admin/src/base/Filter.php
+++ b/modules/admin/src/base/Filter.php
@@ -62,7 +62,7 @@ abstract class Filter extends Object implements FilterInterface
     /**
      * @var mixed|array Private property to store the effect params list
      */
-    private $_effectParamsList = null;
+    private $_effectParamsList;
 
     /**
      * Add message to log array.

--- a/modules/admin/src/base/Property.php
+++ b/modules/admin/src/base/Property.php
@@ -24,12 +24,12 @@ abstract class Property extends Component implements TypesInterface
     /**
      * @var string The module where the property is located.
      */
-    public $moduleName = null;
+    public $moduleName;
 
     /**
      * @var mixed The value from the database assigned into the property object.
      */
-    public $value = null;
+    public $value;
     
     /**
      * @var boolean Whether the property is used for an i18n use case or not, this will

--- a/modules/admin/src/commands/CrudController.php
+++ b/modules/admin/src/commands/CrudController.php
@@ -29,27 +29,27 @@ class CrudController extends BaseCrudController
     /**
      * @var string The name of the module which should be used in order to generate the crud structure e.g `cmsadmin`.
      */
-    public $moduleName = null;
+    public $moduleName;
     
     /**
      * @var string The name of the model in camelcase notation e.g `NavItem`.
      */
-    public $modelName = null;
+    public $modelName;
     
     /**
      * @var string The name of the API endpoint based on the modelName und moduleName selections e.g `api-cms-navitem`.
      */
-    public $apiEndpoint = null;
+    public $apiEndpoint;
     
     /**
      * @var string The name of the corresponding model database table e.g. `cms_navitem`.
      */
-    public $dbTableName = null;
+    public $dbTableName;
     
     /**
      * @var boolean Whether the i18n text fields will be casted or not.
      */
-    public $enableI18n = null;
+    public $enableI18n;
     
     /**
      * Get the $moduleName without admin suffix (if any).
@@ -111,7 +111,7 @@ class CrudController extends BaseCrudController
         return strtolower($this->getModuleNameWithoutAdminSuffix().'_'.Inflector::underscore($this->modelName));
     }
     
-    private $_dbTableShema = null;
+    private $_dbTableShema;
     
     /**
      * Get the database table schema.
@@ -147,7 +147,7 @@ class CrudController extends BaseCrudController
         return $this->getModule()->basePath;
     }
     
-    private $_modelBasePath = null;
+    private $_modelBasePath;
     
     /**
      * Get the base path of the module.
@@ -181,7 +181,7 @@ class CrudController extends BaseCrudController
         return $this->getModule()->getNamespace();
     }
     
-    private $_modelNamespace = null;
+    private $_modelNamespace;
     
     public function getModelNamespace()
     {

--- a/modules/admin/src/commands/FilterController.php
+++ b/modules/admin/src/commands/FilterController.php
@@ -16,11 +16,11 @@ use luya\helpers\FileHelper;
  */
 class FilterController extends Command
 {
-    public $identifier = null;
+    public $identifier;
     
-    public $name = null;
+    public $name;
     
-    public $chain = null;
+    public $chain;
     
     /**
      * Create a new image filter to apply on an Image Object.

--- a/modules/admin/src/commands/ProxyController.php
+++ b/modules/admin/src/commands/ProxyController.php
@@ -91,7 +91,7 @@ class ProxyController extends Command
      * can define multible tables ab seperating those with a comma `table1,table2,table`. In order to define only tables with start
      * with a given prefix you can use `app_*` using asterisks symbold to define wild card starts with string defintions.
      */
-    public $table = null;
+    public $table;
     
     /**
      * @var string The production environment Domain where your LUYA application is running in production mode make so to use the right protocolo
@@ -100,17 +100,17 @@ class ProxyController extends Command
      * - http://www.example.com
      * 
      */
-    public $url = null;
+    public $url;
     
     /**
      * @var string The identifier you get from the Machines menu in your production env admin looks like this: lcp58e35acb4ca69
      */
-    public $idf = null;
+    public $idf;
 
     /**
      * @var string The token which is used for the identifier, looks like this: ESOH1isB3ka_dF09ozkDJewpeecGCdUw
      */
-    public $token = null;
+    public $token;
     
     /**
      * @inheritdoc

--- a/modules/admin/src/commands/SetupController.php
+++ b/modules/admin/src/commands/SetupController.php
@@ -29,22 +29,22 @@ class SetupController extends \luya\console\Command
     /**
      * @var string The email of the user to create.
      */
-    public $email = null;
+    public $email;
     
     /**
      * @var string The blank password of the user to create.
      */
-    public $password = null;
+    public $password;
     
     /**
      * @var string The firstname of the user to create.
      */
-    public $firstname = null;
+    public $firstname;
     
     /**
      * @var string The lastname of the user to create.
      */
-    public $lastname = null;
+    public $lastname;
     
     /**
      * @var string Whether the setup is interactive or not.
@@ -54,12 +54,12 @@ class SetupController extends \luya\console\Command
     /**
      * @var string The name of the default language e.g. English
      */
-    public $langName = null;
+    public $langName;
     
     /**
      * @var string The short code of the language e.g. en
      */
-    public $langShortCode = null;
+    public $langShortCode;
     
     /**
      * @inheritdoc

--- a/modules/admin/src/components/AdminLanguage.php
+++ b/modules/admin/src/components/AdminLanguage.php
@@ -25,14 +25,14 @@ class AdminLanguage extends Component
      *
      * @var array
      */
-    private $_activeLanguage = null;
+    private $_activeLanguage;
     
     /**
      * Containg all availabe languages from Lang Model.
      *
      * @var array
      */
-    private $_languages = null;
+    private $_languages;
     
     /**
      * Get the array of the current active language (its not an AR object!)

--- a/modules/admin/src/components/AdminMenu.php
+++ b/modules/admin/src/components/AdminMenu.php
@@ -14,9 +14,9 @@ use luya\helpers\ArrayHelper;
  */
 class AdminMenu extends \yii\base\Component
 {
-    private $_menu = null;
+    private $_menu;
 
-    private $_modules = null;
+    private $_modules;
 
     private $_items = [];
 

--- a/modules/admin/src/components/AdminMenuBuilder.php
+++ b/modules/admin/src/components/AdminMenuBuilder.php
@@ -50,7 +50,7 @@ class AdminMenuBuilder extends Object implements AdminMenuBuilderInterface
     /**
      * @var \luya\base\AdminModuleInterface The context on what the menu is running.
      */
-    protected $moduleContext = null;
+    protected $moduleContext;
     
     /**
      * @var array List of all permission APIs.

--- a/modules/admin/src/components/AdminUser.php
+++ b/modules/admin/src/components/AdminUser.php
@@ -44,7 +44,7 @@ class AdminUser extends User
     /**
      * @var string Variable to assign the default language from the admin module in order to set default language if not set.
      */
-    public $defaultLanguage = null;
+    public $defaultLanguage;
     
     /**
      * @inheritdoc

--- a/modules/admin/src/components/Auth.php
+++ b/modules/admin/src/components/Auth.php
@@ -31,7 +31,7 @@ class Auth extends \yii\base\Component
      */
     const CAN_DELETE = 3;
 
-    private $_permissionTable = null;
+    private $_permissionTable;
     
     /**
      * Get all permissions entries for the given User.

--- a/modules/admin/src/components/StorageContainer.php
+++ b/modules/admin/src/components/StorageContainer.php
@@ -131,7 +131,7 @@ class StorageContainer extends Component
     /**
      * @var \luya\web\Request Request object resolved by the Dependency Injector.
      */
-    public $request = null;
+    public $request;
     
     private $_fileCacheKey = 'storage_fileCacheKey';
     
@@ -161,7 +161,7 @@ class StorageContainer extends Component
         parent::__construct($config);
     }
     
-    private $_httpPath = null;
+    private $_httpPath;
     
     /**
      * Setter for the http path in order to read online storage files.
@@ -200,7 +200,7 @@ class StorageContainer extends Component
         return $this->_httpPath;
     }
     
-    private $_absoluteHttpPath = null;
+    private $_absoluteHttpPath;
     
     /**
      * Setter fro the absolute http path in order to read from another storage source.
@@ -240,7 +240,7 @@ class StorageContainer extends Component
         return $this->_absoluteHttpPath;
     }
     
-    private $_serverPath = null;
+    private $_serverPath;
     
     /**
      * Get the internal server path to the storage folder.
@@ -270,7 +270,7 @@ class StorageContainer extends Component
         $this->_serverPath = Yii::getAlias($path);
     }
     
-    private $_filesArray = null;
+    private $_filesArray;
     
     /**
      * Get all storage files as an array from database.
@@ -299,7 +299,7 @@ class StorageContainer extends Component
         return (isset($this->filesArray[$fileId])) ? $this->filesArray[$fileId] : false;
     }
     
-    private $_imagesArray = null;
+    private $_imagesArray;
     
     /**
      * Get all storage images as an array from database.
@@ -605,7 +605,7 @@ class StorageContainer extends Component
         return false;
     }
     
-    private $_foldersArray = null;
+    private $_foldersArray;
     
     /**
      * Get all storage folders as an array from database.
@@ -698,7 +698,7 @@ class StorageContainer extends Component
         return false;
     }
     
-    private $_filtersArray = null;
+    private $_filtersArray;
     
     /**
      * Get all storage filters as an array from database.

--- a/modules/admin/src/events/FileDownloadEvent.php
+++ b/modules/admin/src/events/FileDownloadEvent.php
@@ -6,5 +6,5 @@ class FileDownloadEvent extends \yii\base\Event
 {
     public $isValid = true;
     
-    public $file = null;
+    public $file;
 }

--- a/modules/admin/src/file/Item.php
+++ b/modules/admin/src/file/Item.php
@@ -39,7 +39,7 @@ class Item extends ItemAbstract
 {
     private $_imageMimeTypes = ['image/gif', 'image/jpeg', 'image/png', 'image/jpg', 'image/bmp', 'image/tiff'];
     
-    private $_caption = null;
+    private $_caption;
     
     /**
      * Set caption for file item, override existings values

--- a/modules/admin/src/file/Query.php
+++ b/modules/admin/src/file/Query.php
@@ -17,7 +17,7 @@ class Query extends \yii\base\Object
 {
     use QueryTrait;
     
-    private $_storage = null;
+    private $_storage;
     
     /**
      * Singleton behavior for storage component getter.

--- a/modules/admin/src/folder/Query.php
+++ b/modules/admin/src/folder/Query.php
@@ -17,7 +17,7 @@ class Query extends \yii\base\Object
 {
     use QueryTrait;
     
-    private $_storage = null;
+    private $_storage;
     
     /**
      * Singleton behavior for storage component getter.

--- a/modules/admin/src/image/Item.php
+++ b/modules/admin/src/image/Item.php
@@ -25,9 +25,9 @@ use luya\admin\storage\ItemAbstract;
  */
 class Item extends ItemAbstract
 {
-    private $_file = null;
+    private $_file;
     
-    private $_caption = null;
+    private $_caption;
     
     /**
      * Set caption for image item, override existings values

--- a/modules/admin/src/image/Query.php
+++ b/modules/admin/src/image/Query.php
@@ -17,7 +17,7 @@ class Query extends \yii\base\Object
 {
     use QueryTrait;
     
-    private $_storage = null;
+    private $_storage;
     
     /**
      * Singleton behavior for storage component getter.

--- a/modules/admin/src/models/Lang.php
+++ b/modules/admin/src/models/Lang.php
@@ -123,7 +123,7 @@ final class Lang extends NgRestModel
         return $config;
     }
     
-    private static $_langInstanceQuery = null;
+    private static $_langInstanceQuery;
 
     /**
      * @return array
@@ -137,7 +137,7 @@ final class Lang extends NgRestModel
         return self::$_langInstanceQuery;
     }
 
-    private static $_langInstance = null;
+    private static $_langInstance;
     
     /**
      *
@@ -152,7 +152,7 @@ final class Lang extends NgRestModel
         return self::$_langInstance;
     }
 
-    private static $_langInstanceFindActive = null;
+    private static $_langInstanceFindActive;
     
     /**
      * Get the active langauge array

--- a/modules/admin/src/models/Logger.php
+++ b/modules/admin/src/models/Logger.php
@@ -203,7 +203,7 @@ final class Logger extends NgRestModel
 
     private static $identiferIndex = [];
 
-    private static $requestIdentifier = null;
+    private static $requestIdentifier;
 
     private static function getRequestIdentifier()
     {

--- a/modules/admin/src/models/ProxyBuild.php
+++ b/modules/admin/src/models/ProxyBuild.php
@@ -73,7 +73,7 @@ class ProxyBuild extends NgRestModel
         return 'api-admin-proxybuild';
     }
     
-    private $_arrayConfig = null;
+    private $_arrayConfig;
     
     public function getArrayConfig()
     {

--- a/modules/admin/src/models/User.php
+++ b/modules/admin/src/models/User.php
@@ -46,7 +46,7 @@ final class User extends NgRestModel implements IdentityInterface, ChangePasswor
         $this->on(self::EVENT_BEFORE_VALIDATE, [$this, 'eventBeforeValidate']);
     }
     
-    private $_setting = null;
+    private $_setting;
     
     public function getSetting()
     {

--- a/modules/admin/src/models/UserSetting.php
+++ b/modules/admin/src/models/UserSetting.php
@@ -47,7 +47,7 @@ final class UserSetting extends Object implements \ArrayAccess
 
     public $data = [];
 
-    public $sender = null;
+    public $sender;
 
     private function save()
     {

--- a/modules/admin/src/ngrest/Config.php
+++ b/modules/admin/src/ngrest/Config.php
@@ -65,7 +65,7 @@ class Config extends Object implements ConfigInterface
     	$this->_relations = $relations;
     }
     
-    private $_apiEndpoint = null;
+    private $_apiEndpoint;
     
     public function getApiEndpoint()
     {
@@ -101,7 +101,7 @@ class Config extends Object implements ConfigInterface
     	$this->_filters = $filters;
     }
     
-    private $_defaultOrder = null;
+    private $_defaultOrder;
     
     public function getDefaultOrder()
     {
@@ -113,7 +113,7 @@ class Config extends Object implements ConfigInterface
     	$this->_defaultOrder = $defaultOrder;
     }
     
-    private $_groupByField = null;
+    private $_groupByField;
     
     public function getGroupByField()
     {
@@ -125,7 +125,7 @@ class Config extends Object implements ConfigInterface
     	$this->_groupByField = $groupByField;
     }
     
-    private $_tableName = null;
+    private $_tableName;
     
     public function getTableName()
     {
@@ -137,7 +137,7 @@ class Config extends Object implements ConfigInterface
     	$this->_tableName = $tableName;
     }
     
-    private $_primaryKey = null;
+    private $_primaryKey;
     
     public function getPrimaryKey()
     {
@@ -177,7 +177,7 @@ class Config extends Object implements ConfigInterface
         return '+';
     }
 
-    private $_hash = null;
+    private $_hash;
     
     public function getHash()
     {
@@ -284,7 +284,7 @@ class Config extends Object implements ConfigInterface
         return ($this->getPointer('delete') === true) ? true : false;
     }
 
-    private $_plugins = null;
+    private $_plugins;
     
     /**
      * @todo: combine getPlugins and getExtraFields()
@@ -311,7 +311,7 @@ class Config extends Object implements ConfigInterface
         return $this->_plugins;
     }
 
-    private $_extraFields = null;
+    private $_extraFields;
     
     /**
      * @todo: combine getPlugins and getExtraFields()

--- a/modules/admin/src/ngrest/ConfigBuilder.php
+++ b/modules/admin/src/ngrest/ConfigBuilder.php
@@ -19,9 +19,9 @@ use luya\helpers\ArrayHelper;
  */
 class ConfigBuilder implements ConfigBuilderInterface
 {
-    protected $pointer = null;
+    protected $pointer;
 
-    protected $field = null;
+    protected $field;
 
     protected $config = [];
 
@@ -35,7 +35,7 @@ class ConfigBuilder implements ConfigBuilderInterface
     /**
      * @var string When the ConfigBuilder is created, this property must be fulfilled by the constructor:
      */
-    public $ngRestModelClass = null;
+    public $ngRestModelClass;
     
     /**
      * Maig setter function, defines whether a pointer exists or not, if not existing it will be created.

--- a/modules/admin/src/ngrest/NgRest.php
+++ b/modules/admin/src/ngrest/NgRest.php
@@ -31,9 +31,9 @@ use luya\admin\ngrest\render\RenderInterface;
  */
 class NgRest
 {
-    private $config = null;
+    private $config;
 
-    private $render = null;
+    private $render;
 
     /**
      * Create new NgRest Object.

--- a/modules/admin/src/ngrest/aw/ActiveField.php
+++ b/modules/admin/src/ngrest/aw/ActiveField.php
@@ -16,17 +16,17 @@ class ActiveField extends Object
     /**
      * @var \luya\admin\ngrest\aw\CallbackFormWidget The form widget object
      */
-    public $form = null;
+    public $form;
     
     /**
      * @var string The attribute name of the field is isued as identifier to send the post data.
      */
-    public $attribute = null;
+    public $attribute;
     
     /**
      * @var string Pre defined value of the option
      */
-    public $value = null;
+    public $value;
     
     /**
      * @var string|boolean A label which is used when no label is provided from class creation config

--- a/modules/admin/src/ngrest/aw/CallbackButtonWidget.php
+++ b/modules/admin/src/ngrest/aw/CallbackButtonWidget.php
@@ -27,12 +27,12 @@ class CallbackButtonWidget extends Widget
     /**
      * @var string The id of the callback if the callback method s name is `callbackSayHello` the callback id would be `say-hello`.
      */
-    public $callback = null;
+    public $callback;
     
     /**
      * @var string The label of the button to display for the user.
      */
-    public $label = null;
+    public $label;
     
     /**
      * @param array $options Define behavior of the button, options are name-value pairs. The following options are available:

--- a/modules/admin/src/ngrest/aw/CallbackFormWidget.php
+++ b/modules/admin/src/ngrest/aw/CallbackFormWidget.php
@@ -54,12 +54,12 @@ class CallbackFormWidget extends Widget
     /**
      * @var string Required value of the Submit Button
      */
-    public $buttonValue = null;
+    public $buttonValue;
     
     /**
      * @var string Required value of the callback in the Active Window which should be triggered by this Form.
      */
-    public $callback = null;
+    public $callback;
 
     /**
      * @var string Optional string with javascript callback function which is going to be triggered after angular response.

--- a/modules/admin/src/ngrest/base/ActiveWindow.php
+++ b/modules/admin/src/ngrest/base/ActiveWindow.php
@@ -40,7 +40,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
     /**
      * @var string the module name in where the active window context is loaded, in order to find view files.
      */
-    public $module = null;
+    public $module;
     
     /**
      * @var string The icon name from goolges material icon set (https://material.io/icons/)
@@ -64,7 +64,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         }
     }
     
-    private $_model = null;
+    private $_model;
     
     /**
      * Get the model object from where the Active Window is attached to.
@@ -80,7 +80,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->_model;
     }
     
-    private $_configHash = null;
+    private $_configHash;
     
     /**
      * @inheritdoc
@@ -100,7 +100,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->_configHash;
     }
     
-    private $_activeWindowHash = null;
+    private $_activeWindowHash;
     
     /**
      * @inheritdoc
@@ -187,7 +187,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->icon;
     }
     
-    private $_name = null;
+    private $_name;
     
     /**
      * Get the ActiveWindow name based on its class short name.
@@ -203,7 +203,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->_name;
     }
     
-    private $_viewFolderName = null;
+    private $_viewFolderName;
     
     /**
      * Get the folder name where the views for this ActiveWindow should be stored.
@@ -225,7 +225,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->_viewFolderName;
     }
     
-    private $_hashName = null;
+    private $_hashName;
     
     /**
      * Get a unique identifier hash based on the name and config values like icon and alias.
@@ -258,7 +258,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return implode(DIRECTORY_SEPARATOR, [Yii::getAlias($module), 'views', 'aws', $this->getViewFolderName()]);
     }
     
-    private $_view = null;
+    private $_view;
     
     /**
      * Get the view object to render templates.
@@ -286,7 +286,7 @@ abstract class ActiveWindow extends Object implements ViewContextInterface, Acti
         return $this->getView()->render($name, $params, $this);
     }
 
-    private $_itemId = null;
+    private $_itemId;
     
     /**
      * @inheritdoc

--- a/modules/admin/src/ngrest/base/Api.php
+++ b/modules/admin/src/ngrest/base/Api.php
@@ -34,7 +34,7 @@ class Api extends RestActiveController
      * public $modelClass = 'admin\models\User';
      * ```
      */
-    public $modelClass = null;
+    public $modelClass;
     
     /**
      * @var boolean Defines whether the automatic pagination should be enabled if more then 200 rows of data stored in this table or not.
@@ -79,7 +79,7 @@ class Api extends RestActiveController
         return $actions;
     }
     
-    private $_model = null;
+    private $_model;
 
     /**
      * @return NgRestModel

--- a/modules/admin/src/ngrest/base/Controller.php
+++ b/modules/admin/src/ngrest/base/Controller.php
@@ -27,7 +27,7 @@ class Controller extends \luya\admin\base\Controller
      * public $modelClass = 'admin\models\User';
      * ```
      */
-    public $modelClass = null;
+    public $modelClass;
 
     /**
      * @var boolean Disables the permission
@@ -46,7 +46,7 @@ class Controller extends \luya\admin\base\Controller
         }
     }
     
-    private $_model = null;
+    private $_model;
 
     /**
      * Get Model Object

--- a/modules/admin/src/ngrest/base/NgRestModel.php
+++ b/modules/admin/src/ngrest/base/NgRestModel.php
@@ -297,7 +297,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
         return $query->select($fields)->all();
     }
 
-    private $_ngrestCallType = null;
+    private $_ngrestCallType;
     
     /**
      * Determine the current call type based on get params as they can change the output behavior to make the ngrest crud list view.
@@ -313,7 +313,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
         return $this->_ngrestCallType;
     }
 
-    private $_ngRestPrimaryKey = null;
+    private $_ngRestPrimaryKey;
 
     /**
      * Getter method for NgRest Primary Key.
@@ -570,7 +570,7 @@ abstract class NgRestModel extends ActiveRecord implements GenericSearchInterfac
         }
     }
     
-    private $_config = null;
+    private $_config;
     
     /**
      * Build and call the full config object if not build yet for this model.

--- a/modules/admin/src/ngrest/base/Plugin.php
+++ b/modules/admin/src/ngrest/base/Plugin.php
@@ -34,17 +34,17 @@ abstract class Plugin extends Component
     /**
      * @var string The name of the field corresponding to the ActiveRecord (also known as fieldname)
      */
-    public $name = null;
+    public $name;
     
     /**
      * @var string The alias name of the plugin choosen by the user (also known as label)
      */
-    public $alias = null;
+    public $alias;
     
     /**
      * @var boolean Whether the plugin is in i18n context or not.
      */
-    public $i18n = null;
+    public $i18n;
 
     /**
      * @var mixed This value will be used when the i18n decodes the given value but is not set yet, default value.

--- a/modules/admin/src/ngrest/plugins/CheckboxRelation.php
+++ b/modules/admin/src/ngrest/plugins/CheckboxRelation.php
@@ -73,17 +73,17 @@ class CheckboxRelation extends Plugin
     /**
      * @var string The reference table table name e.g. `admin_user_groupadmin_user_group`.
      */
-    public $refJoinTable = null;
+    public $refJoinTable;
 
     /**
      * @var string The reference table model field name e.g `group_id`.
      */
-    public $refModelPkId = null;
+    public $refModelPkId;
 
     /**
      * @var string The reference table poin field name e.g. `user_id`.
      */
-    public $refJoinPkId = null;
+    public $refJoinPkId;
 
     /**
      * @var array A list of fields which should be used for the display template. Can also be a callable function to build the field with the template
@@ -94,12 +94,12 @@ class CheckboxRelation extends Plugin
      * }
      * ```
      */
-    public $labelFields = null;
+    public $labelFields;
 
     /**
      * @var string The template which is sued for the label fields like the sprinf command e.g. `%s %s (%s)`.
      */
-    public $labelTemplate = null;
+    public $labelTemplate;
 
     /**
      * @var boolean Whether the checkbox plugin should only trigger for the restcreate and restupdate events or for all SAVE/UPDATE events.
@@ -117,7 +117,7 @@ class CheckboxRelation extends Plugin
         $this->addEvent(NgRestModel::EVENT_AFTER_UPDATE, [$this, 'afterSaveEvent']);
     }
     
-    private $_modelPrimaryKey = null;
+    private $_modelPrimaryKey;
     
     public function getModelPrimaryKey()
     {

--- a/modules/admin/src/ngrest/plugins/Number.php
+++ b/modules/admin/src/ngrest/plugins/Number.php
@@ -29,7 +29,7 @@ class Number extends Plugin
     /**
      * @var integer Html field placeholder
      */
-    public $placeholder = null;
+    public $placeholder;
 
     public function renderList($id, $ngModel)
     {

--- a/modules/admin/src/ngrest/plugins/SelectArray.php
+++ b/modules/admin/src/ngrest/plugins/SelectArray.php
@@ -20,7 +20,7 @@ use luya\helpers\ArrayHelper;
  */
 class SelectArray extends Select
 {
-    private $_data = null;
+    private $_data;
     
     public function setData(array $data)
     {

--- a/modules/admin/src/ngrest/plugins/SelectModel.php
+++ b/modules/admin/src/ngrest/plugins/SelectModel.php
@@ -42,7 +42,7 @@ class SelectModel extends Select
     /**
      * @var string The className of the ActiveRecord or NgRestModel in order to build the ActiveQuery find methods.
      */
-    public $modelClass = null;
+    public $modelClass;
     
     /**
      * @var string|array|callable An array or string to select the data from, this data will be returned in the select overview.
@@ -61,7 +61,7 @@ class SelectModel extends Select
      * }
      * ```
      */
-    public $labelField = null;
+    public $labelField;
     
     /**
      * @var boolean|string If enabled you can defined how the placed variables should be strucutred. For example in combination with array labels:
@@ -154,7 +154,7 @@ class SelectModel extends Select
         return implode(" ", $values);
     }
     
-    private $_valueField = null;
+    private $_valueField;
     
     /**
      * Getter Method for valueField.

--- a/modules/admin/src/ngrest/plugins/Slug.php
+++ b/modules/admin/src/ngrest/plugins/Slug.php
@@ -18,7 +18,7 @@ class Slug extends Plugin
     /**
      * @var integer Html field placeholder
      */
-    public $placeholder = null;
+    public $placeholder;
 
     public function renderList($id, $ngModel)
     {

--- a/modules/admin/src/ngrest/plugins/SortRelationArray.php
+++ b/modules/admin/src/ngrest/plugins/SortRelationArray.php
@@ -4,7 +4,7 @@ namespace luya\admin\ngrest\plugins;
 
 class SortRelationArray extends SortRelation
 {
-    private $_data = null;
+    private $_data;
     
     public function getData()
     {

--- a/modules/admin/src/ngrest/plugins/SortRelationModel.php
+++ b/modules/admin/src/ngrest/plugins/SortRelationModel.php
@@ -18,11 +18,11 @@ namespace luya\admin\ngrest\plugins;
  */
 class SortRelationModel extends SortRelation
 {
-    public $modelClass = null;
+    public $modelClass;
     
-    public $valueField = null;
+    public $valueField;
     
-    public $labelField = null;
+    public $labelField;
     
     public function getData()
     {

--- a/modules/admin/src/ngrest/plugins/Text.php
+++ b/modules/admin/src/ngrest/plugins/Text.php
@@ -14,7 +14,7 @@ class Text extends Plugin
     /**
      * @var string Define a HTML placeholder attribute.
      */
-    public $placeholder = null;
+    public $placeholder;
     
     /**
      * @var array An array with options can be passed to the createListTag.

--- a/modules/admin/src/ngrest/plugins/Textarea.php
+++ b/modules/admin/src/ngrest/plugins/Textarea.php
@@ -29,7 +29,7 @@ class Textarea extends Plugin
     /**
      * @var string Html5 placholder attribute value to set and example for the user
      */
-    public $placeholder = null;
+    public $placeholder;
 
     /**
      * @var boolean Defines whether the textarea output value should be nl2br or not. This only will be triggerd after find (in frontend output).

--- a/modules/admin/src/ngrest/render/RenderActiveWindow.php
+++ b/modules/admin/src/ngrest/render/RenderActiveWindow.php
@@ -10,9 +10,9 @@ use luya\admin\ngrest\base\Render;
  */
 class RenderActiveWindow extends Render implements RenderInterface
 {
-    private $_itemId = null;
+    private $_itemId;
 
-    public $activeWindowHash = null;
+    public $activeWindowHash;
     
     public function render()
     {

--- a/modules/admin/src/ngrest/render/RenderCrud.php
+++ b/modules/admin/src/ngrest/render/RenderCrud.php
@@ -29,13 +29,13 @@ class RenderCrud extends Render implements RenderInterface, ViewContextInterface
 
     private $_permissions = [];
 
-    private $_buttons = null;
+    private $_buttons;
 
-    private $_view = null;
+    private $_view;
 
     private $_fields = [];
 
-    private $_langs = null;
+    private $_langs;
 
     public function can($type)
     {
@@ -247,7 +247,7 @@ class RenderCrud extends Render implements RenderInterface, ViewContextInterface
         return $this->_langs;
     }
 
-    private $_defaultLangShortCode = null;
+    private $_defaultLangShortCode;
 
     public function getDefaultLangShortCode()
     {

--- a/modules/admin/src/proxy/ClientBuild.php
+++ b/modules/admin/src/proxy/ClientBuild.php
@@ -13,27 +13,27 @@ class ClientBuild extends Object
     /**
      * @var \luya\console\Command $command object
      */
-    public $command = null;
+    public $command;
     
-    public $buildToken = null;
+    public $buildToken;
     
-    public $requestUrl = null;
+    public $requestUrl;
     
-    public $requestCloseUrl = null;
+    public $requestCloseUrl;
     
-    public $fileProviderUrl = null;
+    public $fileProviderUrl;
     
-    public $imageProviderUrl = null;
+    public $imageProviderUrl;
     
-    public $machineIdentifier = null;
+    public $machineIdentifier;
 
-    public $machineToken = null;
+    public $machineToken;
     
-    public $storageFilesCount = null;
+    public $storageFilesCount;
     
-    public $optionStrict = null;
+    public $optionStrict;
     
-    private $_optionTable = null;
+    private $_optionTable;
     
     public function setOptionTable($table)
     {
@@ -62,7 +62,7 @@ class ClientBuild extends Object
         }
     }
     
-    private $_buildConfig = null;
+    private $_buildConfig;
     
     public function setBuildConfig(array $config)
     {

--- a/modules/admin/src/proxy/ClientTable.php
+++ b/modules/admin/src/proxy/ClientTable.php
@@ -14,12 +14,12 @@ use yii\helpers\Console;
  */
 class ClientTable extends Object
 {
-    private $_data = null;
+    private $_data;
     
     /**
      * @var \luya\admin\proxy\ClientBuild
      */
-    public $build = null;
+    public $build;
     
     public function __construct(ClientBuild $build, array $data, array $config = [])
     {
@@ -28,7 +28,7 @@ class ClientTable extends Object
         parent::__construct($config);
     }
     
-    private $_schema = null;
+    private $_schema;
     
     public function getSchema()
     {
@@ -100,7 +100,7 @@ class ClientTable extends Object
         return $this->getRows() == count($this->getContentRows());
     }
     
-    private $_contentRows = null;
+    private $_contentRows;
     
     public function getContentRows()
     {

--- a/modules/admin/src/storage/QueryTrait.php
+++ b/modules/admin/src/storage/QueryTrait.php
@@ -63,9 +63,9 @@ trait QueryTrait
 {
     private $_where = [];
     
-    private $_offset = null;
+    private $_offset;
     
-    private $_limit = null;
+    private $_limit;
     
     private $_whereOperators = ['<', '<=', '>', '>=', '=', '==', 'in'];
     

--- a/modules/admin/tests/admin/aws/ChangePasswordActiveWindowTest.php
+++ b/modules/admin/tests/admin/aws/ChangePasswordActiveWindowTest.php
@@ -7,7 +7,7 @@ use admintests\AdminTestCase;
 
 class ChangePasswordActiveWindowTest extends AdminTestCase
 {
-    public $aws = null;
+    public $aws;
 
     public function setUp()
     {

--- a/modules/cms/src/Menu.php
+++ b/modules/cms/src/Menu.php
@@ -111,25 +111,25 @@ class Menu extends Component implements ArrayAccess
     /**
      * @var \luya\web\Request Request object
      */
-    public $request = null;
+    public $request;
     
     private $_cachePrefix = 'MenuContainerCache';
     
-    private $_currentUrlRule = null;
+    private $_currentUrlRule;
     
-    private $_composition = null;
+    private $_composition;
 
-    private $_current = null;
+    private $_current;
 
-    private $_currentAppendix = null;
+    private $_currentAppendix;
 
     private $_languageContainer = [];
 
-    private $_languages = null;
+    private $_languages;
 
-    private $_redirectMap = null;
+    private $_redirectMap;
     
-    private $_modulesMap = null;
+    private $_modulesMap;
     
     /**
      * Class constructor to DI the request object.

--- a/modules/cms/src/admin/Module.php
+++ b/modules/cms/src/admin/Module.php
@@ -151,7 +151,7 @@ class Module extends \luya\admin\base\Module implements CoreModuleInterface
      */
     public $hiddenBlocks = [];
     
-    private $_blockVariation = null;
+    private $_blockVariation;
     
     /**
      * Set block variations.

--- a/modules/cms/src/admin/apis/MenuController.php
+++ b/modules/cms/src/admin/apis/MenuController.php
@@ -65,7 +65,7 @@ class MenuController extends \luya\admin\base\RestController
         return true;
     }
 
-    private $_groups = null;
+    private $_groups;
 
     private function getGroups()
     {

--- a/modules/cms/src/admin/helpers/MenuHelper.php
+++ b/modules/cms/src/admin/helpers/MenuHelper.php
@@ -17,7 +17,7 @@ use luya\helpers\ArrayHelper;
  */
 class MenuHelper
 {
-    private static $items = null;
+    private static $items;
     
     /**
      * Get all nav data entries with corresponding item content
@@ -79,7 +79,7 @@ class MenuHelper
     
     private static $_inheritData = [];
     
-    private static $_navItems = null;
+    private static $_navItems;
     
     private static function getNavItems()
     {
@@ -129,7 +129,7 @@ class MenuHelper
     
     /* NAV GROUP INHERITANCE NODE */
     
-    private static $_cmsPermissionData = null;
+    private static $_cmsPermissionData;
     
     private static function getCmsPermissionData()
     {
@@ -161,7 +161,7 @@ class MenuHelper
     
     /* NAV GROUP PERMISSION */
     
-    private static $_navGroupPermissions = null;
+    private static $_navGroupPermissions;
     
     private static function getNavGroupPermissions()
     {
@@ -190,7 +190,7 @@ class MenuHelper
         return false;
     }
     
-    private static $containers = null;
+    private static $containers;
     
     /**
      * Get all cms containers
@@ -206,7 +206,7 @@ class MenuHelper
         return self::$containers;
     }
     
-    private static $drafts = null;
+    private static $drafts;
     
     /**
      * Get all drafts nav items

--- a/modules/cms/src/base/BaseBlockInjector.php
+++ b/modules/cms/src/base/BaseBlockInjector.php
@@ -35,12 +35,12 @@ abstract class BaseBlockInjector extends Object
     /**
      * @var string The name of the variable on what the injector should use and listen to.
      */
-    public $varName = null;
+    public $varName;
     
     /**
      * @var string The label used in the administration area for this injector.
      */
-    public $varLabel = null;
+    public $varLabel;
     
     /**
      * @var string The type of variable is used for the inject. can be either var or cfg.
@@ -52,7 +52,7 @@ abstract class BaseBlockInjector extends Object
      */
     public $append = false;
     
-    private $_context = null;
+    private $_context;
     
     /**
      * Setter for the context value must be typeof BlockInterface.

--- a/modules/cms/src/base/BlockConfigElement.php
+++ b/modules/cms/src/base/BlockConfigElement.php
@@ -19,7 +19,7 @@ abstract class BlockConfigElement
 {
     public $item = [];
 
-    protected $id = null;
+    protected $id;
 
     /**
      *

--- a/modules/cms/src/base/BlockVariationRegister.php
+++ b/modules/cms/src/base/BlockVariationRegister.php
@@ -41,7 +41,7 @@ class BlockVariationRegister
     
     private $_variations = [];
     
-    private $_tempIdentifier = null;
+    private $_tempIdentifier;
     
     /**
      * @param InternalBaseBlock $block

--- a/modules/cms/src/base/InternalBaseBlock.php
+++ b/modules/cms/src/base/InternalBaseBlock.php
@@ -41,7 +41,7 @@ abstract class InternalBaseBlock extends Object implements BlockInterface, Types
      */
     const INJECTOR_CFG = 'cfg';
 
-    private $_injectorObjects = null;
+    private $_injectorObjects;
     
     /**
      * Setup injectors.

--- a/modules/cms/src/base/NavItemType.php
+++ b/modules/cms/src/base/NavItemType.php
@@ -41,7 +41,7 @@ abstract class NavItemType extends \yii\db\ActiveRecord
         return []; // override
     }
     
-    private $_controller = null;
+    private $_controller;
     
     /**
      * Setter method to store the current controller Object

--- a/modules/cms/src/base/PhpBlock.php
+++ b/modules/cms/src/base/PhpBlock.php
@@ -15,7 +15,7 @@ use yii\base\ViewContextInterface;
  */
 abstract class PhpBlock extends InternalBaseBlock implements PhpBlockInterface, ViewContextInterface
 {
-    private $_view = null;
+    private $_view;
     
     /**
      * View Object getter.

--- a/modules/cms/src/frontend/base/Controller.php
+++ b/modules/cms/src/frontend/base/Controller.php
@@ -156,7 +156,7 @@ abstract class Controller extends \luya\web\Controller
             $seoAlert++;
         } else {
             foreach ($menu->current->keywords as $word) {
-                if (preg_match_all('/' . preg_quote($word) . '/i', $content, $matches)) {
+                if (preg_match_all('/' . preg_quote($word, '/') . '/i', $content, $matches)) {
                     $keywords[] = [$word, count($matches[0])];
                 } else {
                     $keywords[] = [$word, 0];

--- a/modules/cms/src/frontend/commands/BlockController.php
+++ b/modules/cms/src/frontend/commands/BlockController.php
@@ -36,34 +36,34 @@ class BlockController extends \luya\console\Command
     /**
      * @var string The type of block, valid `app` (static::TYPE_APP) or `module` (static::TYPE_TMODULE) values.
      */
-    public $type = null;
+    public $type;
     
     /**
      * @var string If type is `module` the name of the module must be provided with this $moduleName property.
      */
-    public $moduleName = null;
+    public $moduleName;
     
     /**
      * @var array Provide the configuration array which is inside the `config()` method of the block.
      */
-    public $config = null;
+    public $config;
     
     /**
      * @var boolean Whether the block is a container/layout block or not this will enable/dsiable the $isContainer property
      */
-    public $isContainer = null;
+    public $isContainer;
     
     /**
      * @var boolean Whether the caching property should be displayed or not inside the block.
      */
-    public $cacheEnabled = null;
+    public $cacheEnabled;
     
     /**
      * @var boolean If dry run is enabled the content of the block will be returned but no files will be created. This is usefull for unit testing.
      */
     public $dryRun = false;
     
-    private $_blockName = null;
+    private $_blockName;
     
     /**
      * Setter method for $blockName, ensure the correct block name.

--- a/modules/cms/src/frontend/events/BeforeRenderEvent.php
+++ b/modules/cms/src/frontend/events/BeforeRenderEvent.php
@@ -11,5 +11,5 @@ class BeforeRenderEvent extends \yii\base\Event
 {
     public $isValid = true;
     
-    public $menu = null;
+    public $menu;
 }

--- a/modules/cms/src/frontend/events/MenuItemEvent.php
+++ b/modules/cms/src/frontend/events/MenuItemEvent.php
@@ -25,7 +25,7 @@ namespace luya\cms\frontend\events;
  */
 class MenuItemEvent extends \yii\base\Event
 {
-    public $item = null;
+    public $item;
     
     public function getVisible()
     {

--- a/modules/cms/src/injectors/ActiveQueryCheckboxInjector.php
+++ b/modules/cms/src/injectors/ActiveQueryCheckboxInjector.php
@@ -56,14 +56,14 @@ final class ActiveQueryCheckboxInjector extends BaseBlockInjector
      *
      * If the label attribute is not defined, just all attribute from the model will be displayed.
      */
-    public $label = null;
+    public $label;
     
     /**
      * @var boolean|array Whether the extr assigned data should enable pagination.
      */
     public $pagination = false;
     
-    private $_query = null;
+    private $_query;
     
     /**
      * Setter method for the active query interface.

--- a/modules/cms/src/injectors/TagInjector.php
+++ b/modules/cms/src/injectors/TagInjector.php
@@ -31,7 +31,7 @@ class TagInjector extends BaseBlockInjector
         return Tag::find()->select(['name'])->indexBy('id')->column();
     }
     
-    private $_assignedTags = null;
+    private $_assignedTags;
     
     /**
      * Get assigned models for the current Block.

--- a/modules/cms/src/menu/InjectItem.php
+++ b/modules/cms/src/menu/InjectItem.php
@@ -93,7 +93,7 @@ class InjectItem extends Object implements InjectItemInterface
     
     // Getter & Setter
     
-    private $_item = null;
+    private $_item;
 
     /**
      * Returns the evalutead menu item whether from the childOf property or set from the setter method.
@@ -127,7 +127,7 @@ class InjectItem extends Object implements InjectItemInterface
         return $this;
     }
     
-    private $_childOf = null;
+    private $_childOf;
     
     /**
      * Setter method for childOf property.
@@ -156,7 +156,7 @@ class InjectItem extends Object implements InjectItemInterface
         return $this->_childOf;
     }
     
-    private $_alias = null;
+    private $_alias;
     
     /**
      * Setter methdo for the item alias.
@@ -185,7 +185,7 @@ class InjectItem extends Object implements InjectItemInterface
         return $this->item->alias . '/' . $this->_alias;
     }
     
-    private $_link = null;
+    private $_link;
     
     /**
      * Setter method fro the link.
@@ -210,7 +210,7 @@ class InjectItem extends Object implements InjectItemInterface
         return ($this->_link === null) ? Yii::$app->menu->buildItemLink($this->alias, $this->getLang()) : $this->_link;
     }
     
-    private $_title = null;
+    private $_title;
     
     /**
      * Setter method for the menu title.
@@ -245,7 +245,7 @@ class InjectItem extends Object implements InjectItemInterface
         return $this->_title;
     }
     
-    private $_description = null;
+    private $_description;
     
     /**
      * Setter method for menu page description.
@@ -363,7 +363,7 @@ class InjectItem extends Object implements InjectItemInterface
         return 0;
     }
 
-    private $_id = null;
+    private $_id;
     
     /**
      * Setter methdo for the id (unique id).
@@ -389,7 +389,7 @@ class InjectItem extends Object implements InjectItemInterface
         return $this->_id;
     }
     
-    private $_navId = null;
+    private $_navId;
     
     /**
      * Setter method for the navId.

--- a/modules/cms/src/menu/Item.php
+++ b/modules/cms/src/menu/Item.php
@@ -66,13 +66,13 @@ class Item extends Object implements LinkInterface, Arrayable
      * @var array The item property containing the informations with key  value parinings. This property will be assigned when creating the
      * Item-Object.
      */
-    public $itemArray = null;
+    public $itemArray;
 
     /**
      * @var string|null Can contain the language context, so the sub querys for this item will be the same language context
      * as the parent object which created this object.
      */
-    public $lang = null;
+    public $lang;
     
     /**
      * @var array Privat property containing with informations for the Query Object.
@@ -281,7 +281,7 @@ class Item extends Object implements LinkInterface, Arrayable
         return $this->itemArray['description'];
     }
 
-    private $_keywords = null;
+    private $_keywords;
     
     private $_delimiters = [',', ';', '|'];
     
@@ -545,7 +545,7 @@ class Item extends Object implements LinkInterface, Arrayable
         return count($this->getChildren()) > 0 ? true : false;
     }
     
-    private $_model = null;
+    private $_model;
     
     /**
      * Get the ActiveRecord Model for the current Nav Model.

--- a/modules/cms/src/menu/Query.php
+++ b/modules/cms/src/menu/Query.php
@@ -53,7 +53,7 @@ class Query extends Object
      */
     protected $whereOperators = ['<', '<=', '>', '>=', '=', '==', 'in'];
     
-    private $_menu = null;
+    private $_menu;
     
     /**
      * Getter method to return menu component
@@ -157,7 +157,7 @@ class Query extends Object
         return $this->where($args);
     }
 
-    private $_lang = null;
+    private $_lang;
     
     /**
      * Changeing the container in where the data should be collection, by default the composition
@@ -227,7 +227,7 @@ class Query extends Object
         return $this->_lang;
     }
 
-    private $_limit = null;
+    private $_limit;
     
     /**
      * Set a limition for the amount of results.
@@ -244,7 +244,7 @@ class Query extends Object
         return $this;
     }
     
-    private $_offset = null;
+    private $_offset;
     
     /**
      * Define offset start for the rows, if you defined offset to be 5 and you have 11 rows, the

--- a/modules/cms/src/menu/QueryIterator.php
+++ b/modules/cms/src/menu/QueryIterator.php
@@ -28,7 +28,7 @@ class QueryIterator extends Object implements Iterator
      * @var string|null Can contain the language context, so the sub querys for this item will be the same language context
      * as the parent object which created this object.
      */
-    public $lang = null;
+    public $lang;
 
     /**
      * @see \luya\cms\menu\Query::with()
@@ -53,7 +53,7 @@ class QueryIterator extends Object implements Iterator
         }
     }
     
-    private $_loadModels = null;
+    private $_loadModels;
     
     /**
      * Load all models for ghe given Menu Query.

--- a/modules/cms/src/models/BlockGroup.php
+++ b/modules/cms/src/models/BlockGroup.php
@@ -42,11 +42,6 @@ class BlockGroup extends NgRestModel
         ];
     }
     
-    public static function find()
-    {
-        return Yii::createObject(ActiveQuery::className(), [get_called_class()]);
-    }
-    
     public function ngRestConfig($config)
     {
         $this->ngRestConfigDefine($config, ['list', 'create', 'update'], ['name', 'identifier']);

--- a/modules/cms/src/models/NavItem.php
+++ b/modules/cms/src/models/NavItem.php
@@ -43,7 +43,7 @@ class NavItem extends \yii\db\ActiveRecord implements GenericSearchInterface
 
     const TYPE_REDIRECT = 3;
 
-    public $parent_nav_id = null;
+    public $parent_nav_id;
 
     /**
      * @inheritdoc
@@ -131,7 +131,7 @@ class NavItem extends \yii\db\ActiveRecord implements GenericSearchInterface
         $this->alias = Inflector::slug($this->alias);
     }
     
-    private $_type = null;
+    private $_type;
     
     /**
      * GET the type object based on the nav_item_type defintion and the nav_item_type_id which is the

--- a/modules/cms/src/models/NavItemModule.php
+++ b/modules/cms/src/models/NavItemModule.php
@@ -42,7 +42,7 @@ class NavItemModule extends NavItemType implements NavItemTypeInterface
         ];
     }
 
-    private $_module = null;
+    private $_module;
 
     private function getModule()
     {
@@ -75,7 +75,7 @@ class NavItemModule extends NavItemType implements NavItemTypeInterface
         ];
     }
 
-    private $_content = null;
+    private $_content;
     
     /**
      * @todo: see if $pathAfterRoute could be available in the urlRules, otherwise display default

--- a/modules/cms/src/models/NavItemPage.php
+++ b/modules/cms/src/models/NavItemPage.php
@@ -29,7 +29,7 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
 {
     use CacheableTrait;
 
-    private $_view = null;
+    private $_view;
 
     /**
      * @inheritdoc

--- a/modules/cms/src/models/Property.php
+++ b/modules/cms/src/models/Property.php
@@ -30,7 +30,7 @@ final class Property extends \yii\db\ActiveRecord
         return $this->hasOne(AdminProperty::className(), ['id' => 'admin_prop_id']);
     }
     
-    private $_object = null;
+    private $_object;
     
     public function getObject()
     {

--- a/modules/cms/src/widgets/LangSwitcher.php
+++ b/modules/cms/src/widgets/LangSwitcher.php
@@ -57,7 +57,7 @@ class LangSwitcher extends \luya\base\Widget
     /**
      * @var null|array Singleton container when used for mobile and desktop in order to reduce db requests.
      */
-    private static $_dataArray = null;
+    private static $_dataArray;
     
     /**
      * @var array The Wrapping list element (ul tag) Options to pass.
@@ -114,7 +114,7 @@ class LangSwitcher extends \luya\base\Widget
      * }
      * ```
      */
-    public $itemsCallback = null;
+    public $itemsCallback;
     
     /**
      * Generate the item element.

--- a/modules/cms/src/widgets/NavTree.php
+++ b/modules/cms/src/widgets/NavTree.php
@@ -58,17 +58,17 @@ class NavTree extends Widget
     /**
      * @var null|Item Generate submenus for all pages below you this menu Item
      */
-    private $_startItem = null;
+    private $_startItem;
 
     /**
      * @var null|QueryIteratorFilter The menu Query
      */
-    private $_findQuery = null;
+    private $_findQuery;
 
     /**
      * @var null|integer If set the depth of the menu will be limited
      */
-    public $maxDepth = null;
+    public $maxDepth;
 
     /**
      * @var string The class that should be set on the *active link*
@@ -97,7 +97,7 @@ class NavTree extends Widget
      *
      * You can set all possible html attributes as options
      */
-    public $wrapperOptions = null;
+    public $wrapperOptions;
 
     /**
      * @var array Options for the lists that are generated
@@ -136,17 +136,17 @@ class NavTree extends Widget
     /**
      * @var null|string The list tag will be set during init
      */
-    private $_listTag = null;
+    private $_listTag;
 
     /**
      * @var null|string The item tag will be set during init
      */
-    private $_itemTag = null;
+    private $_itemTag;
 
     /**
      * @var null|string The link tag will be set during init
      */
-    private $_linkTag = null;
+    private $_linkTag;
 
     /**
      * @inheritdoc

--- a/modules/cms/tests/BlockTestCase.php
+++ b/modules/cms/tests/BlockTestCase.php
@@ -6,7 +6,7 @@ namespace cmstests;
 
 class BlockTestCase extends CmsFrontendTestCase
 {
-    public $blockClass = null;
+    public $blockClass;
     
     /**
      * @var \luya\cms\base\PhpBlock

--- a/modules/cms/tests/CmsFrontendTestCase.php
+++ b/modules/cms/tests/CmsFrontendTestCase.php
@@ -9,7 +9,7 @@ require 'data/env.php';
 
 class CmsFrontendTestCase extends \PHPUnit_Framework_TestCase
 {
-    public $app = null;
+    public $app;
     
     public function setUp()
     {

--- a/modules/cms/tests/src/base/BlockTest.php
+++ b/modules/cms/tests/src/base/BlockTest.php
@@ -10,11 +10,6 @@ use luya\cms\base\PhpBlock;
 
 class GetterSetter extends PhpBlock
 {
-    public function extraVars()
-    {
-        return [];
-    }
-
     public function name()
     {
         return 'name';

--- a/modules/crawler/src/frontend/Module.php
+++ b/modules/crawler/src/frontend/Module.php
@@ -42,7 +42,7 @@ class Module extends \luya\base\Module
      * 'baseUrl' => 'https://luya.io',
      * ```
      */
-    public $baseUrl = null;
+    public $baseUrl;
     
     /**
      * @var array An array with regular expression (including delimiters) which will be applied to found links so you can

--- a/modules/crawler/src/frontend/classes/CrawlContainer.php
+++ b/modules/crawler/src/frontend/classes/CrawlContainer.php
@@ -12,11 +12,11 @@ use luya\helpers\Url;
 
 class CrawlContainer extends \yii\base\Object
 {
-    public $baseUrl = null;
+    public $baseUrl;
 
-    public $baseHost = null;
+    public $baseHost;
 
-    public $pageCrawler = null;
+    public $pageCrawler;
 
     public $filterRegex = [];
     

--- a/modules/crawler/src/frontend/classes/CrawlPage.php
+++ b/modules/crawler/src/frontend/classes/CrawlPage.php
@@ -10,17 +10,17 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class CrawlPage extends \yii\base\Object
 {
-    public $pageUrl = null;
+    public $pageUrl;
 
-    public $client = null;
+    public $client;
 
-    public $baseUrl = null;
+    public $baseUrl;
     
-    public $baseHost = null;
+    public $baseHost;
     
     public $useH1 = false;
     
-    private $_crawler = null;
+    private $_crawler;
 
     public $verbose = false;
     

--- a/modules/crawler/tests/frontend/classes/CrawlPageTest.php
+++ b/modules/crawler/tests/frontend/classes/CrawlPageTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class CrawlPageTest extends \PHPUnit_Framework_TestCase
 {
-    public $object = null;
+    public $object;
     
     protected function setUp()
     {

--- a/modules/errorapi/src/Module.php
+++ b/modules/errorapi/src/Module.php
@@ -9,7 +9,7 @@ class Module extends \luya\base\Module implements CoreModuleInterface
 {
     public $recipient = [];
 
-    public $slackToken = null;
+    public $slackToken;
     
     public $slackChannel = '#luya';
 

--- a/modules/errorapi/src/models/Data.php
+++ b/modules/errorapi/src/models/Data.php
@@ -6,9 +6,9 @@ use luya\errorapi\Module;
 
 class Data extends \yii\db\ActiveRecord
 {
-    public $message = null;
+    public $message;
 
-    public $serverName = null;
+    public $serverName;
     
     public $errorArray = [];
 

--- a/modules/remoteadmin/src/models/Site.php
+++ b/modules/remoteadmin/src/models/Site.php
@@ -167,7 +167,7 @@ class Site extends NgRestModel
     	return ($version == self::getCurrentLuyaVersion()['version']) ? 'background-color:#c8e6c9' : 'background-color:#ffcdd2';
     }
     
-    private static $_currentVersion = null;
+    private static $_currentVersion;
     
     public static function getCurrentLuyaVersion()
     {

--- a/tests/LuyaConsoleTestCase.php
+++ b/tests/LuyaConsoleTestCase.php
@@ -10,7 +10,7 @@ require 'data/env.php';
 
 class LuyaConsoleTestCase extends \PHPUnit_Framework_TestCase implements LuyaTestCaseInterface
 {
-    public $app = null;
+    public $app;
 
     public function setUp()
     {

--- a/tests/LuyaWebModuleAppTestCase.php
+++ b/tests/LuyaWebModuleAppTestCase.php
@@ -10,7 +10,7 @@ require 'data/env.php';
 
 class LuyaWebModuleAppTestCase extends \PHPUnit_Framework_TestCase implements LuyaTestCaseInterface
 {
-    public $app = null;
+    public $app;
 
     public function setUp()
     {

--- a/tests/LuyaWebTestCase.php
+++ b/tests/LuyaWebTestCase.php
@@ -10,7 +10,7 @@ require 'data/env.php';
 
 class LuyaWebTestCase extends \PHPUnit_Framework_TestCase implements LuyaTestCaseInterface
 {
-    public $app = null;
+    public $app;
 
     public function setUp()
     {

--- a/tests/core/rest/ControllerTest.php
+++ b/tests/core/rest/ControllerTest.php
@@ -9,9 +9,9 @@ use yii\base\Model;
 
 class FooModel extends Model
 {
-    public $firstname = null;
+    public $firstname;
     
-    public $email = null;
+    public $email;
     
     public function rules()
     {

--- a/tests/core/validators/FloatValidatorTest.php
+++ b/tests/core/validators/FloatValidatorTest.php
@@ -8,7 +8,7 @@ use luya\validators\FloatValidator;
 
 class StubModel extends Model
 {
-    public $value = null;
+    public $value;
 }
 
 class FloatValidatorTest extends LuyaWebTestCase

--- a/tests/data/models/DummyBaseModel.php
+++ b/tests/data/models/DummyBaseModel.php
@@ -6,9 +6,9 @@ use yii\base\Model;
 
 class DummyBaseModel extends Model
 {
-    public $foo = null;
+    public $foo;
     
-    public $bar = null;
+    public $bar;
     
     public function rules()
     {


### PR DESCRIPTION
- It's not needed to initialise properties with `null`, that's default in PHP.
- `preg_quote` should be used with specifying separator.
- Removed two method overrides where new method body is exactly the same as parent.