### PR TITLE
small fixing for non-numeric select value

### DIFF
--- a/modules/admin/src/ngrest/plugins/Select.php
+++ b/modules/admin/src/ngrest/plugins/Select.php
@@ -40,7 +40,7 @@ abstract class Select extends Plugin
     {
         $value = StringHelper::typeCast($event->sender->getAttribute($this->name));
         foreach ($this->data as $item) {
-            if ($item['value'] === $value) {
+            if (StringHelper::typeCast($item['value']) === $value) {
                 $event->sender->setAttribute($this->name, $item['label']);
             }
         }

--- a/modules/admin/src/ngrest/plugins/SelectModel.php
+++ b/modules/admin/src/ngrest/plugins/SelectModel.php
@@ -204,7 +204,7 @@ class SelectModel extends Select
         foreach (static::getDataInstance($class, $this->where) as $item) {
             
             $data[] = [
-                'value' => (int) $item->{$this->valueField},
+                'value' => StringHelper::typeCast($item->{$this->valueField}),
                 'label' => $this->generateLabelField($item),
             ];
         }


### PR DESCRIPTION
We need to check whether the SelectModel value is numeric or not, instead of force-converting it all as integer. In my case, some of the referenced values are just like number eg. 011200, and the other are just plain string eg. G1ABDY, but they are all actually strings. FYI, in my case, for some reasons, the referenced column is also not set as the primary key.

The ngRestAttributeTypes function in my NgRestModel is just like below

```php
    public function ngRestAttributeTypes()
    {
        return [
            // ....
            'KODE_KANTOR' => [
                'selectModel',
                'modelClass' => ReferensiKantorPabean::className(),
                'valueField' => 'KODE_KANTOR',
                'labelField' => ['KODE_KANTOR', 'URAIAN_KANTOR'],
                'labelTemplate' => '(%s) %s',
            ],
            'KODE_NEGARA_PENGIRIM' => [
                'selectModel',
                'modelClass' => ReferensiNegara::className(),
                'valueField' => 'KODE_NEGARA',
                'labelField' => ['KODE_NEGARA', 'URAIAN_NEGARA'],
                'labelTemplate' => '(%s) %s',
            ],
            'NETTO' => 'decimal',
            'NILAI_INCOTERM' => 'decimal',
            'CREATED_DATE' => 'text',
            'UPDATED_DATE' => 'text',
            // ....
        ];
    }
```

And the DDLs for those tables are like these

```sql
CREATE TABLE `referensi_kantor_pabean` (
  `ID` bigint(20) NOT NULL AUTO_INCREMENT,
  `KODE_KANTOR` varchar(255) DEFAULT NULL,
  `URAIAN_KANTOR` varchar(255) DEFAULT NULL,
  `CREATED_DATE` datetime DEFAULT current_timestamp(),
  `UPDATED_DATE` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
  PRIMARY KEY (`ID`),
  KEY `ref_kantor_idx` (`KODE_KANTOR`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=249 DEFAULT CHARSET=latin1;

CREATE TABLE `tpb_header` (
  `ID` bigint(20) NOT NULL AUTO_INCREMENT,
  `KODE_KANTOR` varchar(255) DEFAULT NULL,
  `KODE_NEGARA_PENGIRIM` varchar(255) DEFAULT NULL,
  `NETTO` decimal(38,4) DEFAULT NULL,
  `NILAI_INCOTERM` decimal(38,4) DEFAULT NULL,
  `CREATED_DATE` datetime DEFAULT current_timestamp(),
  `UPDATED_DATE` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
  PRIMARY KEY (`ID`),
  KEY `tpb_kodenegarapengirim_idx` (`KODE_NEGARA_PENGIRIM`) USING BTREE
  KEY `tpb_kantor_idx` (`KODE_KANTOR`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=180 DEFAULT CHARSET=latin1;
```