### PR TITLE
Fix typo on line 72

### DIFF
--- a/docs/guide/luya-console.md
+++ b/docs/guide/luya-console.md
@@ -69,7 +69,7 @@ class NotifyController extends \luya\console\Command
 
     public function actionBar()
     {
-        return $this->ouputError('Something failed inside this action');
+        return $this->outputError('Something failed inside this action');
     }
 }
 ```


### PR DESCRIPTION
from 
return $this->ouputError('Something failed inside this action');

to 
return $this->outputError('Something failed inside this action');

### What are you changing/introducing



### What is the reason for changing/introducing



### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | yes/no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
