### PR TITLE
 Added new option `Composer::$hideDefaultPrefixOnly` 

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Added
 
 + [#174](https://github.com/luyadev/luya-module-admin/issues/174) Added new option $apiRules in order to provide custom url rules for APIS.
++ Added new option `Composer::$hideDefaultPrefixOnly` When enabled, composition prefixes will be hidden only for default language. Takes effect only when `hidden` option is disabled.
 
 ### Fixed
 

--- a/core/web/Composition.php
+++ b/core/web/Composition.php
@@ -59,6 +59,12 @@ class Composition extends Component implements \ArrayAccess
     public $hidden = true;
 
     /**
+     * @var boolean Disable composition prefixes in URLs only for default language. Takes effect only when `hidden` option is disabled.
+     * @since 1.0.10
+     */
+    public $hideDefaultPrefixOnly = false;
+
+    /**
      * @var string Url matching prefix, which is used for all the modules (e.g. an e-store requireds a language
      * as the cms needs this informations too). After proccessing this informations, they will be removed
      * from the url for further proccessing.
@@ -240,9 +246,9 @@ class Composition extends Component implements \ArrayAccess
      */
     public function createRouteEnsure(array $overrideKeys = [])
     {
-        return $this->hidden ? '' : $this->createRoute($overrideKeys);
+        return $this->hidden || (!$this->hidden && $this->langShortCode == $this->defaultLangShortCode && $this->hideDefaultPrefixOnly) ? '' : $this->createRoute($overrideKeys);
     }
-    
+
     /**
      * Create compositon route based on the provided keys (to override), if no keys provided
      * all the default values will be used.


### PR DESCRIPTION
### What are you changing/introducing

Added new option `Composer::$hideDefaultPrefixOnly` When enabled, composition prefixes will be hidden only for default language. Takes effect only when `hidden` option is disabled.


### What is the reason for changing/introducing

Some websites treat root as default language, and use prefixes for secondary languages, for example:

`company.com/about`
`company.com/fr/about`

I'm sorry I don't code tests, hopefully somebody can help.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    |  no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | n/a
| Fixed issues  | 