### PR TITLE
Fix Composition::createRouteEnsure

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
++ [#1902](https://github.com/luyadev/luya/pull/1902) Composition component hides alternate url lang codes when hideDefaultPrefixOnly is true and current lang code is default.
 + [#1898](https://github.com/luyadev/luya/issues/1898) Telephone link raises an exception if an invalid telephone number is provided.
 + [#1897](https://github.com/luyadev/luya/issues/1897) Yii_* constants where not available in config files as Yii entry script was loaded after config files.
 + [#1888](https://github.com/luyadev/luya/issues/1888) Fixed issue with range values which can have float values.

--- a/core/web/Composition.php
+++ b/core/web/Composition.php
@@ -246,7 +246,13 @@ class Composition extends Component implements \ArrayAccess
      */
     public function createRouteEnsure(array $overrideKeys = [])
     {
-        return $this->hidden || (!$this->hidden && $this->langShortCode == $this->defaultLangShortCode && $this->hideDefaultPrefixOnly) ? '' : $this->createRoute($overrideKeys);
+        $langShortCode = '';
+        if (isset ($overrideKeys['langShortCode'])) {
+            $langShortCode = $overrideKeys['langShortCode'];
+        } else {
+            $langShortCode = $this->langShortCode;
+        }
+        return $this->hidden || (!$this->hidden && $langShortCode == $this->defaultLangShortCode && $this->hideDefaultPrefixOnly) ? '' : $this->createRoute($overrideKeys);
     }
 
     /**

--- a/core/web/Composition.php
+++ b/core/web/Composition.php
@@ -246,8 +246,7 @@ class Composition extends Component implements \ArrayAccess
      */
     public function createRouteEnsure(array $overrideKeys = [])
     {
-        $langShortCode = '';
-        if (isset ($overrideKeys['langShortCode'])) {
+        if (isset($overrideKeys['langShortCode'])) {
             $langShortCode = $overrideKeys['langShortCode'];
         } else {
             $langShortCode = $this->langShortCode;

--- a/tests/core/web/CompositionTest.php
+++ b/tests/core/web/CompositionTest.php
@@ -317,5 +317,15 @@ class CompositionTest extends \luyatests\LuyaWebTestCase
         $this->assertSame('de', $composition->createRouteEnsure()); // is not hidden cause default is `en` and provided in the url is `de/hello/world`.
         $composition = new Composition($request, ['hidden' => false, 'hideDefaultPrefixOnly' => true, 'default' => ['langShortCode' => 'de']]);
         $this->assertSame('', $composition->createRouteEnsure()); // is default `de` and also provided in the url `de/hello/world`
+
+        // not hidden while overriding with alternative to current lang code 
+        $request = new Request(['hostInfo' => 'http://localhost', 'pathInfo' => 'de/hello/world']);
+        $composition = new Composition($request, ['hidden' => false, 'hideDefaultPrefixOnly' => true, 'default' => ['langShortCode' => 'de']]);
+        $this->assertSame('fr', $composition->createRouteEnsure(['langShortCode' => 'fr']));
+
+        // hidden while overriding with alternative to current, but equal to default lang code 
+        $request = new Request(['hostInfo' => 'http://localhost', 'pathInfo' => 'de/hello/world']);
+        $composition = new Composition($request, ['hidden' => false, 'hideDefaultPrefixOnly' => true, 'default' => ['langShortCode' => 'en']]);
+        $this->assertSame('', $composition->createRouteEnsure(['langShortCode' => 'en']));
     }
 }


### PR DESCRIPTION
with hideDefaultPrefixOnly == true composition component should not hide lang code if current lang *is* default but the url being constructed *is not* (e.g. LanguageSwitcher)
