### PR TITLE
allow isAdmin when its a module

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 1.4.1 (4. June 2020)
 
-+ [#2027](https://github.com/luyadev/luya/pull/2027) Fixed regression with `luya\web\Request::$isAdmin` when working with admin module names (introduced in [#2019](https://github.com/luyadev/luya/issues/2019)).
++ [#2027](https://github.com/luyadev/luya/pull/2027) Fixed regression with `luya\web\Request::$isAdmin` when working with admin module names like `newsadmin/default/index` (introduced in [#2019](https://github.com/luyadev/luya/issues/2019)).
 
 ## 1.4.0 (2. June 2020)
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 1.4.1 (4. June 2020)
+
++ [#2027](https://github.com/luyadev/luya/pull/2027) Fixed regression with `luya\web\Request::$isAdmin` when working with admin module names (introduced in [#2019](https://github.com/luyadev/luya/issues/2019)).
+
 ## 1.4.0 (2. June 2020)
 
 + [#2019](https://github.com/luyadev/luya/issues/2019) The property `luya\web\Request::$isAdmin` is now more restrict and won't match admin modules like `newsadmin` which would have been evaulated as true before this change.

--- a/core/base/Boot.php
+++ b/core/base/Boot.php
@@ -24,7 +24,7 @@ abstract class Boot
     /**
      * @var string The current LUYA version (see: https://github.com/luyadev/luya/blob/master/core/CHANGELOG.md)
      */
-    const VERSION = '1.4.0';
+    const VERSION = '1.4.1';
     
     /**
      * @var string The path to the config file, which returns an array containing you configuration.

--- a/core/web/Request.php
+++ b/core/web/Request.php
@@ -71,7 +71,11 @@ class Request extends \yii\web\Request
                     $resolver = Yii::$app->composition->getResolvedPathInfo($this);
                     $parts = explode('/', $resolver->resolvedPath);
                     $first = reset($parts);
-                    if (StringHelper::startsWith($first, 'admin')) {
+
+                    // Check for a full route path where the module ends with admin like `newsadmin` and this module is loaded in the list of modules.
+                    if (count($parts) > 1 && Yii::$app->hasModule($first) && StringHelper::endsWith($first, 'admin'))
+                        $this->_isAdmin = true;
+                    elseif (StringHelper::startsWith($first, 'admin')) {
                         $this->_isAdmin = true;
                     } else {
                         $this->_isAdmin = false;

--- a/core/web/Request.php
+++ b/core/web/Request.php
@@ -73,7 +73,7 @@ class Request extends \yii\web\Request
                     $first = reset($parts);
 
                     // Check for a full route path where the module ends with admin like `newsadmin` and this module is loaded in the list of modules.
-                    if (count($parts) > 1 && Yii::$app->hasModule($first) && StringHelper::endsWith($first, 'admin'))
+                    if (count($parts) > 0 && Yii::$app->hasModule($first) && StringHelper::endsWith($first, 'admin'))
                         $this->_isAdmin = true;
                     elseif (StringHelper::startsWith($first, 'admin')) {
                         $this->_isAdmin = true;

--- a/core/web/Request.php
+++ b/core/web/Request.php
@@ -73,7 +73,8 @@ class Request extends \yii\web\Request
                     $first = reset($parts);
 
                     // Check for a full route path where the module ends with admin like `newsadmin` and this module is loaded in the list of modules.
-                    if (count($parts) > 0 && Yii::$app->hasModule($first) && StringHelper::endsWith($first, 'admin'))
+                    // @see https://github.com/luyadev/luya/pull/2027
+                    if (count($parts) > 0 && StringHelper::endsWith($first, 'admin') && Yii::$app->hasModule($first))
                         $this->_isAdmin = true;
                     elseif (StringHelper::startsWith($first, 'admin')) {
                         $this->_isAdmin = true;

--- a/tests/core/web/RequestTest.php
+++ b/tests/core/web/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace luyatests\core\web;
 
+use luya\admin\Module;
 use Yii;
 use luya\web\Request;
 
@@ -9,6 +10,7 @@ class RequestTest extends \luyatests\LuyaWebTestCase
 {
     public function testisAdmin()
     {
+        $this->app->setModule('newsadmin', ['class' => Module::class]);
         $request = new Request();
         $request->forceWebRequest = true;
         $request->pathInfo = 'admin/test/';
@@ -27,7 +29,7 @@ class RequestTest extends \luyatests\LuyaWebTestCase
         $request = new Request();
         $request->forceWebRequest = true;
         $request->pathInfo = 'newsadmin/foo/test/';
-        $this->assertEquals(false, $request->isAdmin);
+        $this->assertEquals(true, $request->isAdmin);
 
         $request = new Request();
         $request->forceWebRequest = true;


### PR DESCRIPTION
Fix a bug where `newsadmin/default/index` would not return `isAdmin` true and therefore breaks certain situation in luya admin module.

This break has been introduced in `https://github.com/luyadev/luya/issues/2019`