### PR TITLE
string template helper

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 1.5.0
+
++ [#2028](https://github.com/luyadev/luya/pull/2028) New `StringHelper::template()` method to parse variables inside a string containing `{{ name }}` curly brackets.
+
 ## 1.4.1 (4. June 2020)
 
 + [#2027](https://github.com/luyadev/luya/pull/2027) Fixed regression with `luya\web\Request::$isAdmin` when working with admin module names like `newsadmin/default/index` (introduced in [#2019](https://github.com/luyadev/luya/issues/2019)).

--- a/core/base/Boot.php
+++ b/core/base/Boot.php
@@ -24,7 +24,7 @@ abstract class Boot
     /**
      * @var string The current LUYA version (see: https://github.com/luyadev/luya/blob/master/core/CHANGELOG.md)
      */
-    const VERSION = '1.4.1';
+    const VERSION = '1.5.0';
     
     /**
      * @var string The path to the config file, which returns an array containing you configuration.

--- a/core/helpers/StringHelper.php
+++ b/core/helpers/StringHelper.php
@@ -375,4 +375,41 @@ class StringHelper extends BaseStringHelper
 
         return is_numeric($value);
     }
+
+    /**
+     * Templating a string with Variables
+     * 
+     * The variables should be declared as `{{username}}` while the variables array key should contain `username`.
+     * 
+     * Usage example:
+     * 
+     * ```php
+     * $content = StringHelper::template('<p>{{ name }}</p>', ['name' => 'John']);
+     * 
+     * // output: <p>John</p>
+     * ```
+     * 
+     * If a variable is not found, the original curly bracktes will be returned.
+     * 
+     * @param string $template
+     * @param array $variables
+     * @return string
+     * @since 1.5.0
+     */
+    public static function template($template, array $variables = [])
+    {
+        preg_match_all("/{{(.*?)}}/", $template, $matches, PREG_SET_ORDER);
+
+        if (empty($matches)) {
+            return $template;
+        }
+
+        foreach ($matches as $match) {
+            if (array_key_exists(trim($match[1]), $variables)) {
+                $template = str_replace($match[0], $variables[trim($match[1])], $template);
+            }
+        }
+
+        return $template;
+    }
 }

--- a/core/helpers/StringHelper.php
+++ b/core/helpers/StringHelper.php
@@ -391,12 +391,13 @@ class StringHelper extends BaseStringHelper
      * 
      * If a variable is not found, the original curly bracktes will be returned.
      * 
-     * @param string $template
-     * @param array $variables
+     * @param string $template The template to parse. The template may contain double curly brackets variables.
+     * @param array $variables The variables which should be available in the template.
+     * @param boolean $removeEmpty Whether variables in double curly brackets should be removed event the have not be assigned by $variables array.
      * @return string
      * @since 1.5.0
      */
-    public static function template($template, array $variables = [])
+    public static function template($template, array $variables = [], $removeEmpty = false)
     {
         preg_match_all("/{{(.*?)}}/", $template, $matches, PREG_SET_ORDER);
 
@@ -407,6 +408,8 @@ class StringHelper extends BaseStringHelper
         foreach ($matches as $match) {
             if (array_key_exists(trim($match[1]), $variables)) {
                 $template = str_replace($match[0], $variables[trim($match[1])], $template);
+            } elseif ($removeEmpty) {
+                $template = str_replace($match[0], '', $template);
             }
         }
 

--- a/tests/core/helpers/StringHelperTest.php
+++ b/tests/core/helpers/StringHelperTest.php
@@ -222,4 +222,13 @@ EOT;
         $this->assertFalse(StringHelper::filterMatch('hello', '!hello'));
         $this->assertFalse(StringHelper::filterMatch('hello', '!hello', 'hello'));
     }
+
+    public function testTemplate()
+    {
+        $this->assertSame('<p>bar</p>', StringHelper::template('<p>{{foo}}</p>', ['foo' => 'bar']));
+        $this->assertSame('<p>bar</p>', StringHelper::template('<p>{{ foo }}</p>', ['foo' => 'bar']));
+
+        $this->assertSame('<p>bar {{unknown}}</p>', StringHelper::template('<p>{{ foo }} {{unknown}}</p>', ['foo' => 'bar']));
+        $this->assertSame('<p>bar {{unknown}}</p>', StringHelper::template('<p>{{ foo }} {{unknown}}</p>', ['foo' => 'bar', 'xyz' => 'abc']));
+    }
 }

--- a/tests/core/helpers/StringHelperTest.php
+++ b/tests/core/helpers/StringHelperTest.php
@@ -225,6 +225,7 @@ EOT;
 
     public function testTemplate()
     {
+        $this->assertSame('<p>bar</p>', StringHelper::template('<p>bar</p>'));
         $this->assertSame('<p>bar</p>', StringHelper::template('<p>{{foo}}</p>', ['foo' => 'bar']));
         $this->assertSame('<p>bar</p>', StringHelper::template('<p>{{ foo }}</p>', ['foo' => 'bar']));
 

--- a/tests/core/helpers/StringHelperTest.php
+++ b/tests/core/helpers/StringHelperTest.php
@@ -230,5 +230,6 @@ EOT;
 
         $this->assertSame('<p>bar {{unknown}}</p>', StringHelper::template('<p>{{ foo }} {{unknown}}</p>', ['foo' => 'bar']));
         $this->assertSame('<p>bar {{unknown}}</p>', StringHelper::template('<p>{{ foo }} {{unknown}}</p>', ['foo' => 'bar', 'xyz' => 'abc']));
+        $this->assertSame('<p>bar </p>', StringHelper::template('<p>{{ foo }} {{unknown}}</p>', ['foo' => 'bar', 'xyz' => 'abc'], true));
     }
 }


### PR DESCRIPTION
New function to template a string with curly brackets:

{{ name }} = ['name' => 'foo']

result: foo