### PR TITLE
Adjusted LazyLoad to use an options array for `alt` and `title` attri…

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 1.5.1 (in progress)
+
++ [#2031](https://github.com/luyadev/luya/issues/2031) Updated LazyLoad for `options` array so that `alt` and `title` attributes can be passed to it.
+
 ## 1.5.0 (19. June 2020)
 
 + [#2029](https://github.com/luyadev/luya/pull/2029) Ensure `administrator` path does not resolve in `luya\web\Request::$isAdmin` true.

--- a/core/lazyload/LazyLoad.php
+++ b/core/lazyload/LazyLoad.php
@@ -18,6 +18,7 @@ use luya\web\View;
  *
  * @author Basil Suter <basil@nadar.io>
  * @author Marc Stampfli <marc.stampfli@zephir.ch>
+ * @author Alex Schmid <schmid@netfant.ch>
  * @since 1.0.0
  */
 class LazyLoad extends Widget
@@ -63,6 +64,12 @@ class LazyLoad extends Widget
      * @var string Additional classes for the lazy load image.
      */
     public $extraClass;
+
+    /**
+     * @var array Options array for the html tag. This array can be used to pass e.g. a `title` or `alt` tag.
+     * @since 1.5.1
+     */
+    public $options;
 
     /**
      * @inheritdoc
@@ -162,12 +169,12 @@ class LazyLoad extends Widget
 
         if ($this->placeholderSrc) {
             $tag = '<div class="' . $class . '">';
-            $tag .= Html::tag('img', '', ['class' => 'lazy-image lazyimage', 'data-src' => $this->src]);
+            $tag .= Html::tag('img', '', array_merge($this->options, ['class' => 'lazy-image lazyimage', 'data-src' => $this->src]));
             $tag .= Html::tag('img', '', ['class' => 'lazyimage-placeholder-image', 'src' => $this->placeholderSrc]);
             $tag .= '<noscript><img class="lazyimage-image" src="' . $this->src . '" /></noscript>';
             $tag .= '</div>';
         } else {
-            $tag = Html::tag('img', '', ['class' => $class, 'data-src' => $this->src, 'data-width' => $this->width, 'data-height' => $this->height]);
+            $tag = Html::tag('img', '', array_merge($this->options, ['class' => $class, 'data-src' => $this->src, 'data-width' => $this->width, 'data-height' => $this->height]));
             if ($this->width && $this->height) {
                 $tag .= '<div class="lazy-placeholder ' . $class .'"><div style="display: block; height: 0px; padding-bottom: ' . ($this->height / $this->width) * 100 . '%;"></div><div class="loader"></div></div>';
             }

--- a/core/lazyload/LazyLoad.php
+++ b/core/lazyload/LazyLoad.php
@@ -69,7 +69,7 @@ class LazyLoad extends Widget
      * @var array Options array for the html tag. This array can be used to pass e.g. a `title` or `alt` tag.
      * @since 1.5.1
      */
-    public $options;
+    public $options = [];
 
     /**
      * @inheritdoc

--- a/tests/core/lazyload/LazyLoadTest.php
+++ b/tests/core/lazyload/LazyLoadTest.php
@@ -9,6 +9,12 @@ class LazyLoadTest extends LuyaWebTestCase
 {
     public function testWidget()
     {
-        $this->assertSame('<img class="lazy-image add" data-src="abc.jpg"><noscript><img class="lazy-image add" src="abc.jpg" /></noscript>', LazyLoad::widget(['src' => 'abc.jpg', 'extraClass' => 'add']));
+        $this->assertSame('<img class="lazy-image add" data-src="abc.jpg"><noscript><img class="lazy-image add" src="abc.jpg" /></noscript>',
+            LazyLoad::widget(['src' => 'abc.jpg', 'extraClass' => 'add']));
+    }
+
+    public function testWidgetWithOptions() {
+        $this->assertSame('<img class="lazy-image add" alt="The image alt" title="The image title" data-src="abc.jpg"><noscript><img class="lazy-image add" src="abc.jpg" /></noscript>',
+            LazyLoad::widget(['src' => 'abc.jpg', 'extraClass' => 'add', 'options' => ['alt' => 'The image alt', 'title' => 'The image title']]));
     }
 }


### PR DESCRIPTION
### What are you changing/introducing
LazyLoad options array for e. g. `alt` and `title` tag.

### What is the reason for changing/introducing
[#2031](https://github.com/luyadev/luya/issues/2031)


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | I hope so
| Fixed issues  | this closes #2031
