### PR TITLE
ensure only files are returned if requested

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -11,6 +11,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#2081](https://github.com/luyadev/luya/pull/2081) Removed deprecated methods and/or added a deprecation error trigger.
 + [#2077](https://github.com/luyadev/luya/pull/2077) Fix issue with caching when using SVG widget and symbol names.
 + [#2085](https://github.com/luyadev/luya/pull/2085) Option to disable language override by resolved composition content in UrlManager.
++ [#2089](https://github.com/luyadev/luya/pull/2089) Ensure that `scanDirectoryFiles()` returns only files and not folders.
 
 ## 1.9.0 (11. February 2021)
 

--- a/core/console/commands/ImportController.php
+++ b/core/console/commands/ImportController.php
@@ -96,6 +96,7 @@ class ImportController extends Command implements ImportControllerInterface
         foreach (scandir($path) as $file) {
             if (substr($file, 0, 1) !== '.') {
                 $files[] = [
+                    'isFile' => is_file($path.DIRECTORY_SEPARATOR.$file),
                     'file' => $file,
                     'filePath' => $path.DIRECTORY_SEPARATOR.$file,
                     'module' => $module,
@@ -116,7 +117,9 @@ class ImportController extends Command implements ImportControllerInterface
         if (array_key_exists($folderName, $this->_dirs)) {
             foreach ($this->_dirs[$folderName] as $folder) {
                 foreach ($folder['files'] as $file) {
-                    $files[] = $file;
+                    if ($file['isFile']) {
+                        $files[] = $file;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Ensure only file paths are returned if requested. otherwise folders are included as well which could throw an error