### PR TITLE
remove attribute labels

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 2.0.3
+
++ [#2118](https://github.com/luyadev/luya/pull/2118) Remove conflicting attributeLabels property from DynamicModel.
+
 ## 2.0.2 (7. December 2021)
 
 + [#2113](https://github.com/luyadev/luya/pull/2113) Improve error handling for expected composition values configuration.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 2.0.3
 
-+ [#2118](https://github.com/luyadev/luya/pull/2118) Remove conflicting attributeLabels property from DynamicModel.
++ [#2118](https://github.com/luyadev/luya/pull/2118) Removed conflicting `$attributeLabels` property from DynamicModel (Yii provides this option since 2.0.35, therefore not required by LUYA anymore).
 
 ## 2.0.2 (7. December 2021)
 

--- a/core/base/DynamicModel.php
+++ b/core/base/DynamicModel.php
@@ -11,8 +11,7 @@ use Yii;
  *
  * ```php
  * $model = new DynamicModel(['query']);
- * $model->attributeLabels = ['query' => 'Search term'];
- * $model->attributeHints = ['query' => 'Enter a search term in order to find articles.'];
+ * $model->setAttributeHints(['query' => 'Enter a search term in order to find articles.']);
  * $model->addRule(['query'], 'string');
  * $model->addRule(['query'], 'required');
  * ```
@@ -26,24 +25,30 @@ class DynamicModel extends \yii\base\DynamicModel
      * @var array An array with key value pairing where key is the attribute and value the label.
      * @since 1.0.15
      */
-    public $attributeHints = [];
+    public $_attributeHints = [];
 
     /**
-     * @var array Assignable attributes by array where key is the label key value the label for the key.
+     * Sets the attribute hints in a massive way.
+     *
+     * @param array $hints Array of attribute hints
+     * @return $this
+     * @since 2.0.3
      */
-    public $attributeLabels = [];
-    
-    /**
-     * {@inheritDoc}
-     */
-    public function attributeLabels()
+    public function setAttributeHints(array $hints)
     {
-        $labels = [];
-        foreach ($this->attributeLabels as $key => $value) {
-            $labels[$key] = Yii::t('app', $value);
-        }
-        
-        return $labels;
+        $this->_attributeHints = $hints;
+        return $this;
+    }
+
+    /**
+     * Get all hints for backwards compatibility.
+     * 
+     * @return array
+     * @since 2.0.3
+     */
+    public function getAttributeHints()
+    {
+        return $this->_attributeHints;
     }
 
     /**


### PR DESCRIPTION
attributelabels can be set in yii base dynamic model, this conflicts with the luya implementation. therefore remove. 